### PR TITLE
Added vhost options/limits and Added shovel parameters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        rmq_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        rmq_version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     env:
       RABBITMQ_VERSION: ${{ matrix.rmq_version }}

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make bin
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-rabbitmq
 ...

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ $ make build
 Using the provider
 ------------------
 
-The provider supports versions `3.10.x` and `3.9.x` of RabbitMQ. It may still work with versions `3.8.x` and `3.7.x`, however these versions are no longer officialy supported.
+The provider supports versions `3.13.x`, `3.12.x` and `3.11.x` of RabbitMQ. It may still work with versions `3.10.x`, `3.9.x` and `3.8.x`, however these versions are no longer officialy supported.
 
-For information on RabbitMQ versions, see the RabbitMQ [version documentation](https://www.rabbitmq.com/versions.html) and [changelog](https://www.rabbitmq.com/changelog.html).
+For information on RabbitMQ versions, see the RabbitMQ [Release Information](https://www.rabbitmq.com/release-information).
 
 
 Developing the Provider

--- a/rabbitmq/resource_shovel.go
+++ b/rabbitmq/resource_shovel.go
@@ -121,6 +121,12 @@ func resourceShovel() *schema.Resource {
 							Optional:      true,
 							ForceNew:      true,
 						},
+						"destination_queue_arguments": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							ForceNew: true,
+							Default:  nil,
+						},
 						"destination_uri": {
 							Type:      schema.TypeString,
 							Required:  true,
@@ -256,6 +262,7 @@ func ReadShovel(d *schema.ResourceData, meta interface{}) error {
 	info["destination_properties"] = shovelInfo.Definition.DestinationProperties
 	info["destination_protocol"] = shovelInfo.Definition.DestinationProtocol
 	info["destination_publish_properties"] = shovelInfo.Definition.DestinationPublishProperties
+	info["destination_queue_arguments"] = shovelInfo.Definition.DestinationQueueArgs
 	info["destination_queue"] = shovelInfo.Definition.DestinationQueue
 	if len(shovelInfo.Definition.DestinationURI) > 0 {
 		info["destination_uri"] = shovelInfo.Definition.DestinationURI[0]
@@ -385,6 +392,10 @@ func setShovelDefinition(shovelMap map[string]interface{}) interface{} {
 
 	if v, ok := shovelMap["destination_queue"].(string); ok {
 		shovelDefinition.DestinationQueue = v
+	}
+
+	if v, ok := shovelMap["destination_queue_arguments"].(map[string]interface{}); ok {
+		shovelDefinition.DestinationQueueArgs = v
 	}
 
 	if v, ok := shovelMap["destination_uri"].(string); ok {

--- a/rabbitmq/resource_shovel_test.go
+++ b/rabbitmq/resource_shovel_test.go
@@ -146,6 +146,13 @@ resource "rabbitmq_shovel" "shovelTest" {
 		source_exchange_key = "test"
 		destination_uri = "amqp:///test"
 		destination_queue = "${rabbitmq_queue.test.name}"
+		destination_publish_properties = {
+			reply_to = "test2.local"
+			correlation_id = "gfdgdfgdfg"
+		}
+		destination_queue_arguments = {
+			x-queue-type = "classic"
+		}
 	}
 }`
 

--- a/rabbitmq/resource_vhost.go
+++ b/rabbitmq/resource_vhost.go
@@ -3,6 +3,7 @@ package rabbitmq
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	rabbithole "github.com/michaelklishin/rabbit-hole/v2"
 
@@ -14,6 +15,7 @@ func resourceVhost() *schema.Resource {
 		Create: CreateVhost,
 		Read:   ReadVhost,
 		Delete: DeleteVhost,
+		Update: UpdateVhost,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -23,6 +25,37 @@ func resourceVhost() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			// "tags": {
+			// 	Type:     schema.TypeList,
+			// 	Elem:     &schema.Schema{Type: schema.TypeString},
+			// 	Optional: true,
+			// 	ForceNew: true,
+			// },
+			"default_queue_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"tracing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+			},
+			"max_connections": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"max_queues": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
 			},
 		},
 	}
@@ -35,13 +68,148 @@ func CreateVhost(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] RabbitMQ: Attempting to create vhost %s", vhost)
 
-	resp, err := rmqc.PutVhost(vhost, rabbithole.VhostSettings{})
+	var settings rabbithole.VhostSettings
+
+	if v, ok := d.Get("default_queue_type").(string); ok && v != "" {
+		settings.DefaultQueueType = v
+	}
+
+	if v, ok := d.Get("description").(string); ok && v != "" {
+		settings.Description = v
+	}
+
+	if v, ok := d.Get("tracing").(bool); ok {
+		settings.Tracing = v
+	}
+
+	limits := make(rabbithole.VhostLimitsValues)
+
+	if v, ok := d.GetOk("max_connections"); ok {
+		v_int, err := strconv.Atoi(v.(string))
+		if err != nil {
+			log.Printf("[ERROR] RabbitMQ: Error converting max_connections to int: %#v", err)
+		}
+		limits["max-connections"] = v_int
+	}
+
+	if v, ok := d.GetOk("max_queues"); ok {
+		v_int, err := strconv.Atoi(v.(string))
+		if err != nil {
+			log.Printf("[ERROR] RabbitMQ: Error converting max_queues to int: %#v", err)
+		}
+		limits["max-queues"] = v_int
+	}
+
+	resp, err := rmqc.PutVhost(vhost, settings)
+	log.Printf("[DEBUG] RabbitMQ: vhost creation response: %#v", resp)
+	if err != nil {
+		return err
+	}
+
+	resp, err = rmqc.PutVhostLimits(vhost, limits)
 	log.Printf("[DEBUG] RabbitMQ: vhost creation response: %#v", resp)
 	if err != nil {
 		return err
 	}
 
 	d.SetId(vhost)
+
+	return ReadVhost(d, meta)
+}
+
+func UpdateVhost(d *schema.ResourceData, meta interface{}) error {
+	rmqc := meta.(*rabbithole.Client)
+
+	vhost, err := rmqc.GetVhost(d.Id())
+	if err != nil {
+		return checkDeleted(d, err)
+	}
+
+	vhost_limits_info, err := rmqc.GetVhostLimits(d.Id())
+	if err != nil {
+		return checkDeleted(d, err)
+	}
+
+	var settings rabbithole.VhostSettings
+	limits := make(rabbithole.VhostLimitsValues)
+
+	if d.HasChange("description") {
+		_, newDescription := d.GetChange("description")
+
+		if v, ok := newDescription.(string); ok && v != "" {
+			settings.Description = v
+		}
+	} else {
+		settings.Description = vhost.Description
+	}
+
+	if d.HasChange("default_queue_type") {
+		_, newDefaultQueueType := d.GetChange("default_queue_type")
+
+		if v, ok := newDefaultQueueType.(string); ok && v != "" {
+			settings.DefaultQueueType = v
+		}
+	} else {
+		settings.DefaultQueueType = vhost.DefaultQueueType
+	}
+
+	if d.HasChange("tracing") {
+		_, newTracing := d.GetChange("tracing")
+
+		if v, ok := newTracing.(bool); ok {
+			settings.Tracing = v
+		}
+	} else {
+		settings.Tracing = vhost.Tracing
+	}
+
+	if _, ok := d.GetOk("max_connections"); ok {
+		if d.HasChange("max_connections") {
+			_, newMaxConnections := d.GetChange("max_connections")
+
+			if v, ok := newMaxConnections.(string); ok {
+				limits["max-connections"], err = strconv.Atoi(v)
+				if err != nil {
+					log.Printf("[ERROR] RabbitMQ: Error converting max_connections to int: %#v", err)
+				}
+			}
+		} else {
+			limits["max-connections"] = vhost_limits_info[0].Value["max-connections"]
+		}
+	}
+
+	if _, ok := d.GetOk("max_queues"); ok {
+		if d.HasChange("max_queues") {
+			_, newMaxQueues := d.GetChange("max_queues")
+
+			if v, ok := newMaxQueues.(string); ok {
+				limits["max-queues"], err = strconv.Atoi(v)
+				if err != nil {
+					log.Printf("[ERROR] RabbitMQ: Error converting max_queues to int: %#v", err)
+				}
+			}
+		} else {
+			limits["max-queues"] = vhost_limits_info[0].Value["max-queues"]
+		}
+	}
+
+	resp, err := rmqc.PutVhost(vhost.Name, settings)
+	log.Printf("[DEBUG] RabbitMQ: vhost creation response: %#v", resp)
+	if err != nil {
+		return err
+	}
+
+	resp, err = rmqc.DeleteVhostLimits(vhost.Name, rabbithole.VhostLimits{"max-connections", "max-queues"})
+	log.Printf("[DEBUG] RabbitMQ: vhost limits deletion response: %#v", resp)
+	if err != nil {
+		return err
+	}
+
+	resp, err = rmqc.PutVhostLimits(vhost.Name, limits)
+	log.Printf("[DEBUG] RabbitMQ: vhost limits creation response: %#v", resp)
+	if err != nil {
+		return err
+	}
 
 	return ReadVhost(d, meta)
 }
@@ -56,7 +224,32 @@ func ReadVhost(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] RabbitMQ: Vhost retrieved: %#v", vhost)
 
+	vhost_limits_info, err := rmqc.GetVhostLimits(d.Id())
+	if err != nil {
+		return checkDeleted(d, err)
+	}
+
+	log.Printf("[DEBUG] RabbitMQ: Vhost retrieved: %#v", vhost)
+
 	d.Set("name", vhost.Name)
+	d.Set("description", vhost.Description)
+	// d.Set("tags", vhost.Tags)
+	d.Set("tracing", vhost.Tracing)
+
+	if len(vhost_limits_info) > 0 {
+		if val, ok := vhost_limits_info[0].Value["max-connections"]; ok {
+			d.Set("max_connections", strconv.Itoa(val))
+		} else {
+			d.Set("max_connections", "") // set as unlimited
+		}
+
+		if val, ok := vhost_limits_info[0].Value["max-queues"]; ok {
+			d.Set("max_queues", strconv.Itoa(val))
+		} else {
+			d.Set("max_queues", "") // set as unlimited
+		}
+
+	}
 
 	return nil
 }

--- a/rabbitmq/resource_vhost_test.go
+++ b/rabbitmq/resource_vhost_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccVhost(t *testing.T) {
+func TestAccVhost_basic(t *testing.T) {
 	var vhost string
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -29,6 +29,33 @@ func TestAccVhost(t *testing.T) {
 				// would be created without error.
 				PreConfig: forceDropVhost(&vhost),
 				Config:    testAccVhostConfig_basic,
+				Check: testAccVhostCheck(
+					"rabbitmq_vhost.test", &vhost,
+				),
+			},
+		},
+	})
+}
+
+func TestAccVhost_settings(t *testing.T) {
+	var vhost string
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccVhostCheckDestroy(vhost),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVhostConfig_settings,
+				Check: testAccVhostCheck(
+					"rabbitmq_vhost.test", &vhost,
+				),
+			},
+			{
+				// Test that, once a vhost has been created and stored in the
+				// state, even if it disappears from the RabbitMQ cluster, it
+				// would be created without error.
+				PreConfig: forceDropVhost(&vhost),
+				Config:    testAccVhostConfig_settings,
 				Check: testAccVhostCheck(
 					"rabbitmq_vhost.test", &vhost,
 				),
@@ -102,4 +129,13 @@ func testAccVhostCheckDestroy(name string) resource.TestCheckFunc {
 const testAccVhostConfig_basic = `
 resource "rabbitmq_vhost" "test" {
     name = "test"
+}`
+
+const testAccVhostConfig_settings = `
+resource "rabbitmq_vhost" "test" {
+    name = "test"
+	description = "test description"
+	tracing = true
+	max_connections = 100
+	max_queues = 200
 }`

--- a/website/docs/r/shovel.html.markdown
+++ b/website/docs/r/shovel.html.markdown
@@ -45,6 +45,9 @@ resource "rabbitmq_shovel" "shovelTest" {
 		source_exchange_key = "test"
 		destination_uri = "amqp:///test"
 		destination_queue = "${rabbitmq_queue.test.name}"
+		destination_queue_arguments = {
+			x-queue-type = "classic"
+		}
 	}
 }
 ```
@@ -101,6 +104,8 @@ Either this or `destination_queue` must be specified but not both.
 
 * `destination_publish_properties` - (Optional) A map of properties to overwrite when shovelling messages.
 
+* `destination_queue_arguments` - (Optional) A map of agurments to add into the queue.
+
 * `prefetch_count` - (Optional; **Deprecated**, please use `source_prefetch_count`) The maximum number of unacknowledged messages copied over a shovel at any one time.
 
 * `reconnect_delay` - (Optional) The duration in seconds to reconnect to a broker after disconnected.
@@ -121,9 +126,9 @@ Either this or `source_queue` must be specified but not both.
 
 * `destination_address` - (Optional) The AMQP 1.0 destination link address.
 
-* `destination_application_properties` - (Optional) Application properties to set when shovelling messages.
+* `destination_application_properties` - (Optional) A map of application properties to set when shovelling messages.
 
-* `destination_properties` - (Optional) Properties to overwrite when shovelling messages.
+* `destination_properties` - (Optional) A map of properties to overwrite when shovelling messages.
 
 For more details regarding dynamic shovel parameters please have a look at the official reference documentaion at [RabbitMQ: Configuring Dynamic Shovels](https://www.rabbitmq.com/shovel-dynamic.html).
 

--- a/website/docs/r/vhost.html.markdown
+++ b/website/docs/r/vhost.html.markdown
@@ -23,6 +23,10 @@ resource "rabbitmq_vhost" "my_vhost" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the vhost.
+* `description` - (Optional) A friendly description.
+* `default_queue_type` - (Optional) default queue type for new queues
+* `max_connections` - (Optional) Maximum number of concurrent client connections to the vhost
+* `max_queues` - (Optional) Maximum number of queues that can be created on the vhost
 
 ## Attributes Reference
 

--- a/website/docs/r/vhost.html.markdown
+++ b/website/docs/r/vhost.html.markdown
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the vhost.
 * `description` - (Optional) A friendly description.
-* `default_queue_type` - (Optional) default queue type for new queues
+* `default_queue_type` - (Optional) default queue type for new queues. The available values are _classic_, _quorum_ or _stream_.
 * `max_connections` - (Optional) Maximum number of concurrent client connections to the vhost
 * `max_queues` - (Optional) Maximum number of queues that can be created on the vhost
 


### PR DESCRIPTION
**vhost parameters**
- description - (Optional) A friendly description.
- default_queue_type - (Optional) default queue type for new queues
- max_connections - (Optional) Maximum number of concurrent client connections to the vhost
- max_queues - (Optional) Maximum number of queues that can be created on the vhost

**shovel parameters**
- destination_queue_arguments - (Optional) A map of agurments to add into the queue.

> Fork  Pull request cyrilgdn#66 : @Galvill @mqhenning 
