### PR TITLE
Import `default_queue_type` when reading vhost resource

### DIFF
--- a/internal/provider/resource_vhost.go
+++ b/internal/provider/resource_vhost.go
@@ -32,19 +32,19 @@ func resourceVhost() *schema.Resource {
 				Description: "A friendly description.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 			},
 			"default_queue_type": {
 				Description: "Default queue type for new queues. The available values are `classic`, `quorum` or `stream`.",
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 			},
 			"tracing": {
 				Description: "To enable/disable tracing.",
 				Type:        schema.TypeBool,
 				Optional:    true,
-				ForceNew:    false,
+				ForceNew:    true,
 			},
 			"max_connections": {
 				Description: "To limit the total number of concurrent client connections in vhost.",

--- a/internal/provider/resource_vhost.go
+++ b/internal/provider/resource_vhost.go
@@ -45,6 +45,7 @@ func resourceVhost() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
+				Default:     false,
 			},
 			"max_connections": {
 				Description: "To limit the total number of concurrent client connections in vhost.",

--- a/internal/provider/resource_vhost.go
+++ b/internal/provider/resource_vhost.go
@@ -240,6 +240,11 @@ func ReadVhost(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", vhost.Name)
 	d.Set("description", vhost.Description)
+
+	if vhost.DefaultQueueType != "" && vhost.DefaultQueueType != "undefined" {
+		d.Set("default_queue_type", vhost.DefaultQueueType)
+	}
+
 	// d.Set("tags", vhost.Tags)
 	d.Set("tracing", vhost.Tracing)
 

--- a/internal/provider/resource_vhost_test.go
+++ b/internal/provider/resource_vhost_test.go
@@ -136,6 +136,7 @@ const testAccVhostConfig_settings = `
 resource "rabbitmq_vhost" "test" {
     name = "test"
 	description = "test description"
+	default_queue_type = "quorum"
 	tracing = true
 	max_connections = 100
 	max_queues = 200


### PR DESCRIPTION
I tried to `terraform import` an existing vhost resource and everything matched my local definitions when I ran `terraform plan`, except for `default_queue_type`.

Also setting `ForceNew` on `description`, `default_queue_type` and `tracing`, as none of these fields can be edited once a vhost is created.

The `tracing` field also comes back from the vhosts API as `false` by default. Reflecting that default in the terraform schema as well to prevent false mismatches on import.