### PR TITLE
Bump go version from 1.23 to 1.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![GitHub License](https://img.shields.io/github/license/rfd59/terraform-provider-rabbitmq)
 
 ![Go version](https://img.shields.io/github/go-mod/go-version/rfd59/terraform-provider-rabbitmq)
+[![Go Report Card](https://goreportcard.com/badge/github.com/terraform-providers/terraform-provider-rabbitmq)](https://goreportcard.com/report/github.com/terraform-providers/terraform-provider-rabbitmq)
 ![Build Status](https://img.shields.io/github/actions/workflow/status/rfd59/terraform-provider-rabbitmq/.github%2Fworkflows%2Fbuild.yml?label=build)
 ![Test Status](https://img.shields.io/github/actions/workflow/status/rfd59/terraform-provider-rabbitmq/.github%2Fworkflows%2Ftest.yml?label=test)
 [![codecov](https://codecov.io/gh/rfd59/terraform-provider-rabbitmq/graph/badge.svg?token=6DNXX7N0IM)](https://codecov.io/gh/rfd59/terraform-provider-rabbitmq)
@@ -56,7 +57,7 @@ resource "rabbitmq_vhost" "example" {
 
 ### Requirements
 - [Terraform](https://www.terraform.io/downloads.html) **1.0+**
-- [Go](https://golang.org/doc/install) **1.23**
+- [Go](https://golang.org/doc/install) **1.24**
 - [Docker Engine](https://docs.docker.com/engine/install) **>= 27.2.x**
 - [Docker Compose plugin](https://docs.docker.com/compose/install/#scenario-two-install-the-compose-plugin) **>= 2.29.x**
 

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.23.7
+go 1.24
 
-toolchain go1.24.1
+toolchain go1.24.6

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0
 	github.com/michaelklishin/rabbit-hole/v3 v3.2.0
-	github.com/stretchr/testify v1.8.3
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.27.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
- Bump go version from 1.23 to 1.24
- Bump github.com/stretchr/testify from 1.8.3 to 1.11.1