### PR TITLE
Add docs for importing resources

### DIFF
--- a/docs/resources/binding.md
+++ b/docs/resources/binding.md
@@ -92,3 +92,12 @@ resource "rabbitmq_binding" "example" {
 
 - `id` (String) The ID of this resource.
 - `properties_key` (String) A unique key to refer to the binding.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Binding can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_binding.example mybinding@myvhost
+```

--- a/docs/resources/federation_upstream.md
+++ b/docs/resources/federation_upstream.md
@@ -67,3 +67,12 @@ Optional:
 - `queue` (String) **Federated Queues Only**: The name of the upstream queue.
 - `reconnect_delay` (Number) Time in seconds to wait after a network link goes down before attempting reconnection. Defaults to `5`.
 - `trust_user_id` (Boolean) Determines how federation should interact with the validated user-id feature. Default is `false`.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Federation upstream can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_federation_upstream.example myfederationupstream@myvhost
+```

--- a/docs/resources/operator_policy.md
+++ b/docs/resources/operator_policy.md
@@ -59,3 +59,12 @@ Required:
 -> **Note:** See the RabbitMQ documentation for definition references and examples.
 - `pattern` (String) A pattern to match an exchange or queue name.
 - `priority` (Number) The policy with the greater priority is applied first.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Opertaor policy can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_operator_policy.example myoperatorpolicy@myvhost
+```

--- a/docs/resources/permissions.md
+++ b/docs/resources/permissions.md
@@ -62,3 +62,12 @@ Required:
 - `configure` (String) The _configure_ ACL
 - `read` (String) The _read_ ACL
 - `write` (String) The _write_ ACL
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Permission can be imported by specifying the user and vhost (with a '@' between each value).
+terraform import rabbitmq_permissions.example myuser@myvhost
+```

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -77,3 +77,12 @@ Required:
 -> **Note:** See the RabbitMQ documentation for definition references and examples.
 - `pattern` (String) A pattern to match an exchange or queue name.
 - `priority` (Number) The policy with the greater priority is applied first.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Policy can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_policy.example mypolicy@myvhost
+```

--- a/docs/resources/queue.md
+++ b/docs/resources/queue.md
@@ -80,3 +80,12 @@ Optional:
 ~> **Note:** Either this or `arguments` must be specified but not both.
 - `auto_delete` (Boolean) Whether the queue will self-delete when all consumers have unsubscribed. Defaults to `false`.
 - `durable` (Boolean) Whether the queue survives server restarts. Defaults to `false`.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Queue can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_queue.example myqueue@myvhost
+```

--- a/docs/resources/shovel.md
+++ b/docs/resources/shovel.md
@@ -109,3 +109,12 @@ Optional:
 - `source_protocol` (String) The protocol to use when connecting to the source. Possible values are `amqp091` or `amqp10`. Defaults to `amqp091`.
 - `source_queue` (String) The queue from which to consume.
 ~> **Note:** Either this or `source_exchange` must be specified but not both.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Shovel can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_shovel.example myshovel@myvhost
+```

--- a/docs/resources/topic_permissions.md
+++ b/docs/resources/topic_permissions.md
@@ -62,3 +62,12 @@ Required:
 - `exchange` (String) The exchange to set the permissions for.
 - `read` (String) The _read_ ACL.
 - `write` (String) The _write_ ACL.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# Topic permissions can be imported by specifying the user and vhost (with a '@' between each value).
+terraform import rabbitmq_topic_permissions.example myuser@myvhost
+```

--- a/examples/resources/rabbitmq_binding/import.sh
+++ b/examples/resources/rabbitmq_binding/import.sh
@@ -1,0 +1,2 @@
+# Binding can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_binding.example mybinding@myvhost

--- a/examples/resources/rabbitmq_federation_upstream/import.sh
+++ b/examples/resources/rabbitmq_federation_upstream/import.sh
@@ -1,0 +1,2 @@
+# Federation upstream can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_federation_upstream.example myfederationupstream@myvhost

--- a/examples/resources/rabbitmq_operator_policy/import.sh
+++ b/examples/resources/rabbitmq_operator_policy/import.sh
@@ -1,0 +1,2 @@
+# Opertaor policy can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_operator_policy.example myoperatorpolicy@myvhost

--- a/examples/resources/rabbitmq_permissions/import.sh
+++ b/examples/resources/rabbitmq_permissions/import.sh
@@ -1,0 +1,2 @@
+# Permission can be imported by specifying the user and vhost (with a '@' between each value).
+terraform import rabbitmq_permissions.example myuser@myvhost

--- a/examples/resources/rabbitmq_policy/import.sh
+++ b/examples/resources/rabbitmq_policy/import.sh
@@ -1,0 +1,2 @@
+# Policy can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_policy.example mypolicy@myvhost

--- a/examples/resources/rabbitmq_queue/import.sh
+++ b/examples/resources/rabbitmq_queue/import.sh
@@ -1,0 +1,2 @@
+# Queue can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_queue.example myqueue@myvhost

--- a/examples/resources/rabbitmq_shovel/import.sh
+++ b/examples/resources/rabbitmq_shovel/import.sh
@@ -1,0 +1,2 @@
+# Shovel can be imported by specifying its name and its vhost (with a '@' between each value).
+terraform import rabbitmq_shovel.example myshovel@myvhost

--- a/examples/resources/rabbitmq_topic_permissions/import.sh
+++ b/examples/resources/rabbitmq_topic_permissions/import.sh
@@ -1,0 +1,2 @@
+# Topic permissions can be imported by specifying the user and vhost (with a '@' between each value).
+terraform import rabbitmq_topic_permissions.example myuser@myvhost


### PR DESCRIPTION
Add docs for importing the following resources:

* `rabbitmq_binding`
* `rabbitmq_federation_upstream`
* `rabbitmq_operator_policy`
* `rabbitmq_permissions`
* `rabbitmq_policy`
* `rabbitmq_queue`
* `rabbitmq_shovel`
* `rabbitmq_topic_permissions`