### PR TITLE
Fix: Automatically add DeprecationMessage to docs

### DIFF
--- a/docs/data-sources/exchange.md
+++ b/docs/data-sources/exchange.md
@@ -4,6 +4,7 @@ page_title: "rabbitmq_exchange Data Source - terraform-provider-rabbitmq"
 subcategory: ""
 description: |-
   Use this data source to access information about an existing exchange.
+  !> This data source is deprecated. Migrate this data source to a dedicated exchange data source. This data source will be removed in the next major version of the provider.
 ---
 
 # rabbitmq_exchange (Data Source)

--- a/docs/resources/exchange.md
+++ b/docs/resources/exchange.md
@@ -4,6 +4,7 @@ page_title: "rabbitmq_exchange Resource - terraform-provider-rabbitmq"
 subcategory: ""
 description: |-
   The rabbitmq_exchange resource creates and manages an exchange.
+  !> This resource is deprecated. Migrate this resource to a dedicated exchange resource. This resource will be removed in the next major version of the provider.
 ---
 
 # rabbitmq_exchange (Resource)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,22 @@ import (
 	rabbithole "github.com/michaelklishin/rabbit-hole/v3"
 )
 
+func init() {
+	schema.DescriptionKind = schema.StringMarkdown
+
+	// Add Deprecation messages to schema description
+	schema.ResourceDescriptionBuilder = func(r *schema.Resource) string {
+		if r.DeprecationMessage != "" {
+			resourceType := "resource"
+			if r.CreateContext == nil && r.Create == nil {
+				resourceType = "data source"
+			}
+			return fmt.Sprintf("%s\n\n!> This %s is deprecated. %s", r.Description, resourceType, r.DeprecationMessage)
+		}
+		return r.Description
+	}
+}
+
 type customHeaderRoundTripper struct {
 	headers   map[string]string
 	transport http.RoundTripper

--- a/templates/data-sources.md.tmpl
+++ b/templates/data-sources.md.tmpl
@@ -15,9 +15,9 @@ description: |-
 ---
 
 # {{.Name}} ({{.Type}})
-{{ if gt (len (split .Description " --- ")) 1 -}}
+{{ if gt (len (split .Description " --- ")) 1 }}
 {{ index (split .Description " --- ") 1 | trimspace }}
-{{ else }}
+{{- else }}
 {{ .Description | trimspace }}
 {{- end }}
 

--- a/templates/resources.md.tmpl
+++ b/templates/resources.md.tmpl
@@ -17,7 +17,7 @@ description: |-
 # {{.Name}} ({{.Type}})
 {{ if gt (len (split .Description " --- ")) 1 -}}
 {{ index (split .Description " --- ") 1 | trimspace | prefixlines "\n" }}
-{{ else }}
+{{- else }}
 {{ .Description | trimspace }}
 {{- end }}
 


### PR DESCRIPTION
The docs have a few changes from the `make doc` output.

This PR attempts to reduce the gap by:
* Automatically including `DeprecationMessage` with the description.
* Tweaking blank lines around description in templates.